### PR TITLE
pathspec 0.12.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set name = "pathspec" %}
-{% set version = "0.10.3" %}
-{% set checksum = "56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6" %}
-{% set build = "0" %}
+{% set version = "0.12.1" %}
 
 package:
   name: {{ name }}
@@ -9,17 +7,18 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ checksum }}
+  sha256: a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712
 
 build:
-  number: {{ build }}
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True  # [py<37]
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<38]
 
 requirements:
   host:
     - python
     - pip
+    - flit-core >=3.2,<4
     - setuptools >=40.8.0
     - wheel
   run:
@@ -35,21 +34,19 @@ test:
     - pathspec
   commands:
     - pip check
-    - pytest --verbose
+    - pytest -v tests
 
 about:
   home: https://github.com/cpburnz/python-path-specification
   license: MPL-2.0
   license_file: LICENSE
   license_family: Other
-  summary: 'Utility library for gitignore style pattern matching of file paths.'
-
+  summary: Utility library for gitignore style pattern matching of file paths.
   description: |
     pathspec is a utility library for pattern matching of file paths. So far
     this only includes Git's wildmatch pattern matching which itself is derived
     from Rsync's wildmatch. Git uses wildmatch for its gitignore files.
   doc_url: https://python-path-specification.readthedocs.io
-  doc_source_url: https://github.com/cpburnz/python-path-specification/blob/master/doc/source/index.rst
   dev_url: https://github.com/cpburnz/python-path-specification
 
 extra:


### PR DESCRIPTION
pathspec 0.12.1 

**Destination channel:** Defaults

### Links

- [PKG-9019]
- dev_url:        https://github.com/cpburnz/python-path-specification/tree/v0.12.1
- conda_forge:    https://github.com/conda-forge/pathspec-feedstock
- pypi:           https://pypi.org/project/pathspec/0.12.1
- pypi inspector: https://inspector.pypi.io/project/pathspec/0.12.1

### Explanation of changes:

- new version number
